### PR TITLE
Customize the Proxies' Name Section to Enable Multiple Connection to a Single FRP Server

### DIFF
--- a/frp-client/config.yaml
+++ b/frp-client/config.yaml
@@ -26,6 +26,7 @@ options:
   webServerUser: "admin"
   webServerPassword: "123456789"
   customDomain: "example.com"
+  proxyName: "homeassistant"
 schema:
   serverAddr: str
   serverPort: int
@@ -34,3 +35,4 @@ schema:
   webServerUser: str
   webServerPassword: str
   customDomain: str
+  proxyName: str

--- a/frp-client/frpc.toml
+++ b/frp-client/frpc.toml
@@ -21,12 +21,10 @@ webServer.password = "123456789"
 
 [[proxies]]
 name = "your_proxy_name"
-type = "http"
-customDomains = ["your_domain"]
-transport.useEncryption = true
-transport.useCompression = true
+type = "tcp"
 localPort = 8123
 localIP = "0.0.0.0"
+remotePort = 25553
 
 # [proxies.plugin]
 # type = "https2http"

--- a/frp-client/frpc.toml
+++ b/frp-client/frpc.toml
@@ -21,10 +21,12 @@ webServer.password = "123456789"
 
 [[proxies]]
 name = "your_proxy_name"
-type = "tcp"
+type = "http"
+customDomains = ["your_domain"]
+transport.useEncryption = true
+transport.useCompression = true
 localPort = 8123
 localIP = "0.0.0.0"
-remotePort = 25553
 
 # [proxies.plugin]
 # type = "https2http"

--- a/frp-client/frpc.toml
+++ b/frp-client/frpc.toml
@@ -20,7 +20,7 @@ webServer.user = "admin"
 webServer.password = "123456789"
 
 [[proxies]]
-name = "homeassistant"
+name = "your_proxy_name"
 type = "http"
 customDomains = ["your_domain"]
 transport.useEncryption = true

--- a/frp-client/run.sh
+++ b/frp-client/run.sh
@@ -17,6 +17,8 @@ sed -i "s/webServer.port = 7500/webServer.port = $(bashio::config 'webServerPort
 sed -i "s/webServer.user = \"admin\"/webServer.user = \"$(bashio::config 'webServerUser')\"/" $CONFIG_PATH
 sed -i "s/webServer.password = \"123456789\"/webServer.password = \"$(bashio::config 'webServerPassword')\"/" $CONFIG_PATH
 sed -i "s/customDomains = \[\"your_domain\"\]/customDomains = [\"$(bashio::config 'customDomain')\"]/" $CONFIG_PATH
+sed -i "s/name = \[\"your_proxy_name\"\]/name = [\"$(bashio::config 'proxyName')\"]/" $CONFIG_PATH
+
 
 bashio::log.info "Starting frp client"
 

--- a/frp-client/run.sh
+++ b/frp-client/run.sh
@@ -17,7 +17,7 @@ sed -i "s/webServer.port = 7500/webServer.port = $(bashio::config 'webServerPort
 sed -i "s/webServer.user = \"admin\"/webServer.user = \"$(bashio::config 'webServerUser')\"/" $CONFIG_PATH
 sed -i "s/webServer.password = \"123456789\"/webServer.password = \"$(bashio::config 'webServerPassword')\"/" $CONFIG_PATH
 sed -i "s/customDomains = \[\"your_domain\"\]/customDomains = [\"$(bashio::config 'customDomain')\"]/" $CONFIG_PATH
-sed -i "s/name = \[\"your_proxy_name\"\]/name = [\"$(bashio::config 'proxyName')\"]/" $CONFIG_PATH
+sed -i "s/name = \"your_proxy_name\"/name = \"$(bashio::config 'proxyName')\"/" $CONFIG_PATH
 
 
 bashio::log.info "Starting frp client"

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: FRP Client
-url: https://github.com/luckywaa/hass-addon-frp-client
+url: https://github.com/huxiaoxu2019/hass-addon-frp-client
 maintainer: Xiaoxu Hu <admin@ihuxu.com>

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: FRP Client
-url: https://github.com/huxiaoxu2019/hass-addon-frp-client
+url: https://github.com/luckywaa/hass-addon-frp-client
 maintainer: Xiaoxu Hu <admin@ihuxu.com>


### PR DESCRIPTION
## Summary
Customize the `name` option under `proxies` group to prevent naming conflicts when enabling multiple connection to a single FRP server.

## Reviewers
@huxiaoxu2019 